### PR TITLE
Always send metrics regardless of exceptions 

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,0 +1,2 @@
+(ns user
+  (:require [midje.repl :refer :all]))

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wikia/commons "0.1.2-SNAPSHOT"
+(defproject wikia/commons "0.1.3-SNAPSHOT"
   :description "Set of common utilities that are useful throughout Wikia's projects"
   :url "https://github.com/Wikia/clojure-commons"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,11 @@
                  [environ "0.5.0"]
                  [org.clojure/clojure "1.6.0"]
 
-
                  ; logger
                  [log4j/log4j "1.2.16" :exclusions [javax.mail/mail javax.jms/jms com.sun.jdmk/jmxtools com.sun.jmx/jmxri]]
                  [org.clojure/tools.logging "0.2.3"]
-                 [org.slf4j/slf4j-log4j12 "1.6.4"]])
+                 [org.slf4j/slf4j-log4j12 "1.6.4"]]
+  :profiles  {:dev  {:source-paths  ["dev"]
+                     :plugins [[lein-midje "3.1.1"]]
+                     :dependencies  [[midje "1.6.3"]]}}
+  :repl-options {:init-ns user})

--- a/test/wikia/common/perfmonitoring/core_test.clj
+++ b/test/wikia/common/perfmonitoring/core_test.clj
@@ -1,0 +1,16 @@
+(ns wikia.common.perfmonitoring.core-test
+  (:require [midje.sweet :refer :all]
+            [wikia.common.perfmonitoring.core :refer :all]))
+
+(facts :series-timing
+  (timing :test (let [x true] x)) => true
+  (provided
+    (get-series-name) => :series
+    (current-time) => 0
+    (publish :series {:test 0}) => nil)
+  
+  (timing :test (throw (Exception. "something failed"))) => (throws Exception)
+  (provided
+    (get-series-name) => :series
+    (current-time) => 0
+    (publish :series {:test 0}) => nil))


### PR DESCRIPTION
Ensure timing metrics are sent while preserving exceptions thrown in the body supplied to the macro. This should help improve the accuracy of our metrics in the case of timeout exceptions by making sure they are always sent.

/cc @nmonterroso @owend 

Related: https://wikia-inc.atlassian.net/browse/PLATFORM-690

This is to make sure that the two plots below match up. We are dropping some of the metrics for the s3-get time because they are timing out and throwing an exception.
![screen shot 2015-01-07 at 12 14 08 pm](https://cloud.githubusercontent.com/assets/21621/5652594/d565821e-9666-11e4-8f41-ebff9d9376dd.png)
